### PR TITLE
Repair a few URLs and remove apply button from website

### DIFF
--- a/book/_config.yml
+++ b/book/_config.yml
@@ -14,7 +14,7 @@ parse:
     dates: "Aug 18-22, 2025"
     github_org_url: "https://github.com/ICESAT-2HackWeek"
     book_repo: "website-2025"
-    website_url: "https://icesat-2-2025.hackweek.io/"
+    website_url: "2025.hackweek.io/"
     jupyterhub_url: "https://hub.cryointhecloud.com/"
     slack_workspace_url: "https://2025-uw-hackweek.slack.com"
     contact_email: "escience-hackweeks@uw.edu"

--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -6,9 +6,9 @@ parts:
 - caption: Details
   chapters:
     - title: Schedule
-      url: https://icesat-2.hackweek.io/index.html?jump_to=schedule
+      url: https://2025.hackweek.io/index.html?jump_to=schedule
     - title: Team
-      url: https://icesat-2.hackweek.io/index.html?jump_to=team
+      url: https://2025.hackweek.io/index.html?jump_to=team
     - file: CoC
 - caption: Logistics
   chapters:

--- a/cookiecutter.yaml
+++ b/cookiecutter.yaml
@@ -1,8 +1,9 @@
 repo_directory: html
 name: ICESat-2 Hackweek
-apply:
-  url: '#'
-  title: Applications by invitation only
+# remove the apply button temporarily
+#apply:
+#  url: '#'
+#  title: Applications by invitation only
 banner:
   description: Building Open Source Software Together
   start_date: 18 August
@@ -42,7 +43,7 @@ sponsors:
   description: ''
   organizations:
   - name: eScience Institute
-    website: ''
+    website: 'https://escience.washington.edu/'
     logo_url: https://escience.washington.edu/wp-content/uploads/2015/10/Logo_eScience-stacked.png
   - name: CryoCloud
     website: https://book.cryointhecloud.com/intro.html


### PR DESCRIPTION
This PR temporarily removes the red applications button from the top right of the hackweek website. It also fixes a few incorrect URLs. 